### PR TITLE
Change mixtral models

### DIFF
--- a/neo4j_haystack_journey.ipynb
+++ b/neo4j_haystack_journey.ipynb
@@ -2073,7 +2073,7 @@
         "* Embed tagline guess using `SentenceTransformersTextEmbedder`. Idea is to search for something that comes to our mind and \"resonates\" with some movie.\n",
         "* Pass query embedding to `Neo4jDynamicDocumentRetriever` which will obtain movies with additional data directly from Neo4j (we do not use `Neo4jDocumentStore` here)\n",
         "* Construct prompt `PromptBuilder` instructing LLM to pick up best matching tagline and compose letter to the movie director explaining the tagline.\n",
-        "* Ask \"Mixtral-8x7B-Instruct-v0.1\" LLM model to generate email letter based on the prompt from the builder.\n",
+        "* Ask \"Mistral-7B-Instruct-v0.2\" LLM model to generate email letter based on the prompt from the builder.\n",
         "* Compose answer data with `AnswerBuilder` component and display results with respective movies found in Neo4j\n"
       ]
     },
@@ -2151,7 +2151,7 @@
         "pipe.add_component(\n",
         "    \"llm\",\n",
         "    HuggingFaceTGIGenerator(\n",
-        "        model=\"mistralai/Mixtral-8x7B-Instruct-v0.1\",\n",
+        "        model=\"mistralai/Mistral-7B-Instruct-v0.2\",\n",
         "        token=HF_TOKEN,\n",
         "        generation_kwargs={\"max_new_tokens\": 500},\n",
         "    ),\n",


### PR DESCRIPTION
Only models on `https://api-inference.huggingface.co/framework/text-generation-inference` are supported by `HuggingFaceTGIGenerator`. We hope to solve this problem soon but till then, you can consider replacing it with "Mistral-7B-Instruct-v0.2" for now